### PR TITLE
SCHUL-103-Error-while-ringing-stop

### DIFF
--- a/src/app/pages/ringtones/ringtones.component.html
+++ b/src/app/pages/ringtones/ringtones.component.html
@@ -18,7 +18,7 @@
     <app-grid-cards
       (delete)="onDeleteRingtone($event)"
       (edit)="onEditRingtone($event)"
-      (play)="togglePlayPause($event)"
+      (play)="togglePlayStop($event)"
       [cards]="cardLength$ | async"
       [cards_height]="220"
       [cards_width]="330"


### PR DESCRIPTION
The issue where a ringtone continued to play after navigating away from the page has been resolved. Additionally, the problem where multiple ringtones could play simultaneously has been addressed. When starting to play a new ringtone, any previously playing ringtone will be stopped automatically. Furthermore, the played ringtone stopped after successful editing as well as after deletion.

Issue: Closes #9